### PR TITLE
fix: Change issuer to the new eve required value

### DIFF
--- a/src/script/src/esi_client.ts
+++ b/src/script/src/esi_client.ts
@@ -17,7 +17,7 @@ interface IHTTPClient {
 class ESIClient {
   private static readonly BASE_URL = 'https://esi.evetech.net';
   private static readonly AUDIENCE = 'EVE Online';
-  private static readonly ISSUER = 'login.eveonline.com';
+  private static readonly ISSUER = 'https://login.eveonline.com';
 
   public static addQueryParam(path: string, paramName: string, paramValue: any): string {
     path += path.includes('?') ? '&' : '?';


### PR DESCRIPTION
The iss according to https://forums.eveonline.com/t/complete-eve-sso-jwt-token-update-on-1-november-11-00-utc/424277 should be https://login.eveonline.com